### PR TITLE
Enable CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci.yaml@add-ci-workflow
+  release:
+    name: Release
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    uses: alphagov/govuk-infrastructure/.github/workflows/release.yaml@add-ci-workflow


### PR DESCRIPTION
This enables a GitHub Action workflow to run CI using a re-usable workflow template in govuk-infrastructure repo. This is the initial set up to test the reusable workflow.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
