### PR TITLE
Add GOVUK_CI_GITHUB_API_TOKEN

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,5 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: test
     uses: alphagov/govuk-infrastructure/.github/workflows/release.yaml@add-ci-workflow
+    secrets:
+      GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
